### PR TITLE
Returning 401 on refresh token expiry error

### DIFF
--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -109,7 +109,7 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
       }
 
       if (token.refreshTokenExpiresAt && token.refreshTokenExpiresAt < new Date()) {
-        throw new InvalidGrantError('Invalid grant: refresh token has expired');
+          throw new InvalidGrantError('Invalid grant: refresh token has expired', { code: 401 });
       }
 
       return token;


### PR DESCRIPTION
Returning code 401 on refresh token expiry. Earlier it was sending 400