### PR TITLE
server error constructor properties changed for jwtToken expiry error

### DIFF
--- a/lib/errors/server-error.js
+++ b/lib/errors/server-error.js
@@ -18,8 +18,8 @@ var util = require('util');
 
 function ServerError(message, properties) {
   properties = _.assign({
-    code: 503,
-    name: 'server_error'
+    code: message.status || 503,
+    name: message.message || 'server_error'
   }, properties);
 
   OAuthError.call(this, message, properties);


### PR DESCRIPTION
customized the serverError constructor properties for JWT token expiry error. Please have a look.